### PR TITLE
Fix theme and language callback handling

### DIFF
--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -1,19 +1,23 @@
 import React, { useState, useEffect } from "react";
 import './LanguageToggle.css';
 
-const LanguageToggle = () => {
-  const [isRussian, setIsRussian] = useState(localStorage.getItem("language") === "ru");
+const LanguageToggle = ({ onLanguageChange }) => {
+  const [isRussian, setIsRussian] = useState(
+    localStorage.getItem("language") === "ru"
+  );
 
   // Изменение языка и добавление data-атрибута к body
   useEffect(() => {
     if (isRussian) {
       document.body.dataset.language = "ru";
       localStorage.setItem("language", "ru");
+      if (onLanguageChange) onLanguageChange("ru");
     } else {
       document.body.dataset.language = "en";
       localStorage.setItem("language", "en");
+      if (onLanguageChange) onLanguageChange("en");
     }
-  }, [isRussian]);
+  }, [isRussian, onLanguageChange]);
 
   return (
     <div

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from "react";
 import './ThemeToggle.css';
 
-const ThemeToggle = () => {
-  const [isDarkMode, setIsDarkMode] = useState(localStorage.getItem("theme") === "dark");
+const ThemeToggle = ({ onChange }) => {
+  const [isDarkMode, setIsDarkMode] = useState(
+    localStorage.getItem("theme") === "dark"
+  );
 
   // Изменение класса body при переключении темы
   useEffect(() => {
@@ -17,8 +19,19 @@ const ThemeToggle = () => {
     }
   }, [isDarkMode]);
 
+  const handleToggle = () => {
+    const nextMode = !isDarkMode;
+    setIsDarkMode(nextMode);
+    if (onChange) {
+      onChange(nextMode);
+    }
+  };
+
   return (
-    <div className={`theme-toggle ${isDarkMode ? "dark-contaner" : ""}`} onClick={() => setIsDarkMode(!isDarkMode)}>
+    <div
+      className={`theme-toggle ${isDarkMode ? "dark-contaner" : ""}`}
+      onClick={handleToggle}
+    >
       <div className={`toggle-circle ${isDarkMode ? "dark" : ""}`}>
         {isDarkMode ? "🌙" : "☀️"}
       </div>


### PR DESCRIPTION
## Summary
- wire up callbacks in `ThemeToggle` and `LanguageToggle` components

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f784fd5c88324b3ecdd6892110a2b